### PR TITLE
configure: local libev via pkg-config

### DIFF
--- a/m4/am-with-libev.m4
+++ b/m4/am-with-libev.m4
@@ -26,6 +26,16 @@ AC_DEFUN([AM_WITH_LIBEV], [
 			fi
 		fi
 
+		EV_CPPFLAGS="`PKG_CONFIG_PATH=${PKG_CONFIG_PATH} pkg-config --cflags libev`"
+		EV_LDFLAGS="`PKG_CONFIG_PATH=${PKG_CONFIG_PATH} pkg-config --libs-only-L libev`"
+		EV_LDFLAGS="${EV_LDFLAGS} `PKG_CONFIG_PATH=${PKG_CONFIG_PATH} pkg-config --libs-only-other libev`"
+		EV_LIBS="`PKG_CONFIG_PATH=${PKG_CONFIG_PATH} pkg-config --libs-only-l libev`"
+
+		AM_VARIABLES_STORE
+
+		LDFLAGS="${LDFLAGS} ${EV_LDFLAGS}"
+		CPPFLAGS="${CPPFLAGS} ${EV_CPPFLAGS}"
+
 		AM_VARIABLES_STORE
 
 		LDFLAGS="${LDFLAGS} ${LIBEV_LDFLAGS}"


### PR DESCRIPTION
libev detection fails on FreeBSD, so I duplicated the curl detection
to use pkgconfig as well. Maybe some of the preceding code can be
deleted now; I'm not familiar enough with configs & m4 to know.